### PR TITLE
Added preview count endpoint

### DIFF
--- a/zendesk/endpoints_v2.py
+++ b/zendesk/endpoints_v2.py
@@ -109,6 +109,10 @@ mapping_table = {
         'path': '/views/preview.json',
         'method': 'POST',
     },
+    'preview_count': {
+        'path': '/views/preview/count.json',
+        'method': 'POST',
+    },
     'count_many_views': {
         'path': '/views/count_many.json',
         'valid_params': ('ids',),


### PR DESCRIPTION
Added descriptor for getting an object count when previewing a view as documented at http://developer.zendesk.com/documentation/rest_api/views.html#preview-count
