### PR TITLE
Update httplib2 to use versions 0.10+.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
 	author_email = 'max@eventbrite.com',
 	packages = ['zendesk'],
 	include_package_data = True,
-	install_requires = ['httplib2', 'simplejson'],
+	install_requires = ['httplib2>=0.10', 'simplejson'],
 	license='LICENSE.txt',
 	url = 'https://github.com/eventbrite/zendesk',
 	keywords = 'zendesk api helpdesk',


### PR DESCRIPTION
In case this package was installed using the old version of httplib2 (0.9.*),
users can run into SNI problems and it is already fixed on versions 0.10+.